### PR TITLE
Update Sonar configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,15 +207,15 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.sonarsource.scanner.maven</groupId>
-          <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.6.0.1398</version>
-        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>3.6.0.1398</version>
+      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M2</version>
@@ -263,7 +263,6 @@
         <sonar.jacoco.reportPaths>impl/target/jacoco.exec</sonar.jacoco.reportPaths>
         <sonar.junit.reportPaths>impl/target/surefire-reports</sonar.junit.reportPaths>
         <sonar.organization>trellis-ldp</sonar.organization>
-        <sonar.projectKey>org.trellisldp:trellis-cassandra</sonar.projectKey>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This should fix the Sonar integration issue. Running it locally via:

`mvn clean verify sonar:sonar -Dsonar.login<....>`

generated the results here: https://sonarcloud.io/dashboard?id=edu.si.trellis%3Atrellis-cassandra

In the Circle-CI web interface, you should be able to add the login token as an environment variable so that it's not in the public logs.