### PR TITLE
filters distinct child content for containment triples

### DIFF
--- a/impl/src/main/java/edu/si/trellis/CassandraResource.java
+++ b/impl/src/main/java/edu/si/trellis/CassandraResource.java
@@ -133,7 +133,7 @@ class CassandraResource implements Resource {
     private Stream<Triple> basicContainmentTriples() {
         RDF rdfFactory = TrellisUtils.getInstance();
         Spliterator<Row> rows = bcontainment.execute(getIdentifier()).spliterator();
-        Stream<IRI> contained = StreamSupport.stream(rows, false).map(r -> r.get("contained", IRI.class));
+        Stream<IRI> contained = StreamSupport.stream(rows, false).map(r -> r.get("contained", IRI.class)).distinct();
         return contained.map(cont -> rdfFactory.createTriple(getIdentifier(), contains, cont))
                         .peek(t -> log.trace("Built containment triple: {}", t));
     }


### PR DESCRIPTION
Super simple PR that's required for filtering out superfluous versions/mementos of a contains triple.