### PR TITLE
Upstream updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <cassandra.test.version>3.11.3</cassandra.test.version>
     <cassandra.driver.version>3.7.0</cassandra.driver.version>
-    <jena.version>3.11.0</jena.version>
+    <jena.version>3.12.0</jena.version>
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <thorntail.version>2.4.0.Final</thorntail.version>
     <tamaya.version>0.4-incubating-SNAPSHOT</tamaya.version>

--- a/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
@@ -2,10 +2,14 @@ package edu.si.trellis;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.trellisldp.api.*;
+import org.trellisldp.http.core.EtagGenerator;
+import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 
 /**
@@ -30,8 +34,9 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Inject
     private AgentService agentService;
 
-    @Inject
-    private NamespaceService namespaceService;
+    @Produces
+    @ApplicationScoped
+    private NamespaceService namespaceService = new NoopNamespaceService();
 
     @Produces
     @ApplicationScoped
@@ -42,6 +47,15 @@ public class CassandraServiceBundler implements ServiceBundler {
 
     @Inject
     private CacheService<String, String> cacheService;
+
+    @Inject
+    private TimemapGenerator timemapGenerator;
+
+    @Inject
+    private EtagGenerator etagGenerator;
+
+    @Inject
+    private Instance<ConstraintService> constraintServices;
 
     @PostConstruct
     void init() {
@@ -81,5 +95,20 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
+    }
+
+    @Override
+    public EtagGenerator getEtagGenerator() {
+        return etagGenerator;
+    }
+
+    @Override
+    public TimemapGenerator getTimemapGenerator() {
+        return timemapGenerator;
+    }
+
+    @Override
+    public Iterable<ConstraintService> getConstraintServices() {
+        return constraintServices;
     }
 }


### PR DESCRIPTION
This updates Jena to be in line with the main trellis codebase (trellis-ldp/trellis#430)

This also updates the ServiceBundler to be in line with upstream (trellis-ldp/trellis#442)

The strange part of this was the need to explicitly create the `NamespaceService`. This _should_ have been instantiated through normal injection, but doing so leads to errors such as:

```
Caused by: org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type NamespaceService with qualifiers @Default
  at injection point [BackedAnnotatedParameter] Parameter 1 of [BackedAnnotatedConstructor] @Inject public org.trellisldp.rdfa.HtmlSerializer(NamespaceService)
  at org.trellisldp.rdfa.HtmlSerializer.<init>(HtmlSerializer.java:0)
```

This PR in its present form _does_ successfully build and the tests pass, but if there are ways to make the `NamespaceService` injection work better, feel free to push commits to this branch.