### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
   include:
     # JDK 8
-    - jdk: oraclejdk8
+    - jdk: openjdk8
 
     # JDK 11
     - jdk: oraclejdk11


### PR DESCRIPTION
The Travis-CI containers don't support oraclejdk8 any longer. This switches the build to use openjdk8