### PR TITLE
Cleaner ENV variable support for Docker machines

### DIFF
--- a/docker-image/docker/Dockerfile
+++ b/docker-image/docker/Dockerfile
@@ -16,4 +16,4 @@ LABEL git.url=${GIT_ORIGIN_REMOTE_URL}
 LABEL git.commit=${GIT_COMMIT_ID_DESCRIBE}
 
 
-CMD ["/command.sh"]
+CMD ["/bin/bash", "/command.sh"]

--- a/docker-image/docker/command.sh
+++ b/docker-image/docker/command.sh
@@ -1,14 +1,4 @@
-#!/bin/sh
-
-# Cassandra Options
-OPTS="-Dcassandra.contactAddress=$CASSANDRA_CONTACT_ADDRESS"
-OPTS="$OPTS -Dcassandra.contactPort=$CASSANDRA_CONTACT_PORT"
-OPTS="$OPTS -Dcassandra.binaryReadConsistency=$CASSANDRA_BINARY_READ_CONSISTENCY"
-OPTS="$OPTS -Dcassandra.binaryWriteConsistency=$CASSANDRA_BINARY_WRITE_CONSISTENCY"
-OPTS="$OPTS -Dcassandra.rdfReadConsistency=$CASSANDRA_RDF_READ_CONSISTENCY"
-OPTS="$OPTS -Dcassandra.rdfWriteConsistency=$CASSANDRA_RDF_WRITE_CONSISTENCY"
-
-
+#!/bin/bash
 
 # HTTP Server Options
 OPTS="$OPTS -Dswarm.undertow.servers.default-server.http-listeners.default.max-post-size=1000000000000"
@@ -21,12 +11,5 @@ OPTS="$OPTS -Dswarm.ajp.enable=false"
 # Logging Options
 OPTS="$OPTS -Dorg.jboss.logging.provider=slf4j"
 OPTS="$OPTS -Dlogback.configurationFile=/logback.xml"
-
-## JMS Options
-OPTS="$OPTS -Dtrellis.jms.use.queue=$TRELLIS_JMS_USE_QUEUE"
-OPTS="$OPTS -Dtrellis.jms.queue=$TRELLIS_JMS_QUEUE_NAME"
-OPTS="$OPTS -Dtrellis.jms.url=$TRELLIS_JMS_URL"
-OPTS="$OPTS -Dtrellis.jms.username=$TRELLIS_JMS_USERNAME"
-OPTS="$OPTS -Dtrellis.jms.password=$TRELLIS_JMS_PASSWORD"
 
 java $OPTS -jar webapp-hollow-thorntail.jar webapp.war

--- a/docker-image/example-stacks/.env
+++ b/docker-image/example-stacks/.env
@@ -1,0 +1,15 @@
+tamaya.ordinal=500
+cassandra.contactAddress="cassandra-1"
+cassandra.contactPort=9042
+cassandra.maxChunkSize=1048576
+cassandra.replicationFactor=1
+cassandra.binaryReadConsistency="ONE"
+cassandra.binaryWriteConsistency="ONE"
+cassandra.rdfReadConsistency="ONE"
+cassandra.rdfWriteConsistency="QUORUM"
+trellis.jms.use.queue="true"
+trellis.jms.queue="trellis"
+trellis.jms.url="tcp://activemq:61616"
+trellis.auth.basic.credentials="/etc/users.auth"
+trellis.auth.webac.cache.size=0
+trellis.auth.webac.cache.expire.seconds=0

--- a/docker-image/example-stacks/docker-full-stack-config.yml
+++ b/docker-image/example-stacks/docker-full-stack-config.yml
@@ -3,20 +3,29 @@ version: "3"
 # https://github.com/thelastpickle/docker-cassandra-bootstrap - monitoring/grafana, other docker details
 services:
   trellis-cassandra:
-    image: trellisldp/trellis-cassandra:0.8.1-SNAPSHOT
+    image: trellisldp/trellis-cassandra:latest
     environment:
-      - CASSANDRA_CONTACT_ADDRESS="cassandra-1"
-      - CASSANDRA_CONTACT_PORT=9042
-      - CASSANDRA_MAX_CHUNK_SIZE=1048576
-      #- CASSANDRA_BINARY_READ_CONSISTENCY="ConsistencyLevel.ONE"
-      #- CASSANDRA_BINARY_WRITE_CONSISTENCY="ConsistencyLevel.ONE"
-      - TRELLIS_JMS_USE_QUEUE="false"
-      - TRELLIS_JMS_QUEUE_NAME="trellis"
-      - TRELLIS_JMS_URL="tcp://activemq:61616"
+      tamaya.ordinal: 500
+      cassandra.contactAddress: "cassandra-1"
+      cassandra.contactPort: 9042
+      cassandra.maxChunkSize: 1048576
+      cassandra.replicationFactor: 1
+      cassandra.binaryReadConsistency: ONE
+      cassandra.binaryWriteConsistency: ONE
+      cassandra.rdfReadConsistency: ONE
+      cassandra.rdfWriteConsistency: QUORUM
+      trellis.jms.use.queue: "true"
+      trellis.jms.queue: "trellis"
+      trellis.jms.url: "tcp://activemq:61616"
+      trellis.auth.basic.credentials: "/etc/users.auth"
+      trellis.auth.webac.cache.size: 0
+      trellis.auth.webac.cache.expire.seconds: 0
     volumes:
       - ./users.auth:/etc/users.auth
     ports:
       - "8080:8080"
+    networks:
+      - trellis-network
     deploy:
       mode: replicated
       replicas: 1
@@ -24,20 +33,17 @@ services:
         condition: on-failure
         max_attempts: 20
         window: 120s
-    links:
-      - cassandra-1
-      - cassandra-2
-      - cassandra-3
-      - activemq
     depends_on:
       - cassandra-1
       - cassandra-2
-      - cassandra-3
       - activemq
   activemq:
     image: rmohr/activemq:latest
     ports:
       - "61616:61616"
+      - "8161:8161"
+    networks:
+      - trellis-network
     deploy:
       restart_policy:
         condition: on-failure
@@ -47,9 +53,8 @@ services:
     image: cassandra
     environment:
       CASSANDRA_BROADCAST_ADDRESS: cassandra-1
-    links:
-      - cassandra-2
-      - cassandra-3
+    networks:
+      - trellis-network
     deploy:
       restart_policy:
         condition: on-failure
@@ -60,9 +65,8 @@ services:
     environment:
       CASSANDRA_BROADCAST_ADDRESS: cassandra-2
       CASSANDRA_SEEDS: cassandra-1
-    links:
-      - cassandra-1
-      - cassandra-3
+    networks:
+      - trellis-network
     deploy:
       restart_policy:
         condition: on-failure
@@ -70,29 +74,16 @@ services:
         window: 120s
     depends_on:
       - cassandra-1
-  cassandra-3:
-    image: cassandra
-    environment:
-      CASSANDRA_BROADCAST_ADDRESS: cassandra-3
-      CASSANDRA_SEEDS: cassandra-1
-    links:
-      - cassandra-1
-      - cassandra-2
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 3
-        window: 120s
-    depends_on:
-      - cassandra-2
   cassandra-init:
     image: trellisldp/trellis-cassandra-init:0.8.1-SNAPSHOT
     depends_on:
-      - cassandra-3
-    links:
-      - cassandra-1
+      - cassandra-2
+    networks:
+      - trellis-network
     deploy:
       restart_policy:
         condition: on-failure
         delay: 30s
-    command: cqlsh cassandra-1 -f /load.cql
+    command: cqlsh cassandra-1 -f /load.cql  # && cqlsh -e "ALTER KEYSPACE trellis WITH REPLICATION = \{'class' : 'SimpleStrategy', 'replication_factor' : $$CASSANDRA_REPLICATION_FACTOR" cassandra-1\}"
+networks:
+  trellis-network:

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -100,7 +100,7 @@
       <artifactId>trellis-webdav</artifactId>
       <version>${trellis.version}</version>
     </dependency>
-    <dependency>
+<!--     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-webac</artifactId>
       <version>${trellis.version}</version>
@@ -110,7 +110,7 @@
           <artifactId>tamaya-api</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
+    </dependency> -->
 
   <!-- Configuration -->
 
@@ -399,40 +399,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>jms</id>
-      <!-- Adds JMS-based EventService implementation-->
-      <dependencies>
-        <dependency>
-          <groupId>org.trellisldp</groupId>
-          <artifactId>trellis-jms</artifactId>
-          <version>${trellis.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.trellisldp</groupId>
-          <artifactId>trellis-event-serialization</artifactId>
-          <version>${trellis.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>basic-webac</id>
-      <!-- Adds WebAC Service and BASIC authorization. -->
-      <dependencies>
-        <dependency>
-          <groupId>org.trellisldp</groupId>
-          <artifactId>trellis-webac</artifactId>
-          <version>${trellis.version}</version>
-        </dependency>
-          <dependency>
-            <groupId>org.trellisldp</groupId>
-            <artifactId>trellis-auth-basic</artifactId>
-            <version>${trellis.version}</version>
-          </dependency>
-      </dependencies>
     </profile>
 
   </profiles>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -100,17 +100,6 @@
       <artifactId>trellis-webdav</artifactId>
       <version>${trellis.version}</version>
     </dependency>
-<!--     <dependency>
-      <groupId>org.trellisldp</groupId>
-      <artifactId>trellis-webac</artifactId>
-      <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency> -->
 
   <!-- Configuration -->
 

--- a/webapp/src/main/java/edu/si/trellis/CassandraApplication.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraApplication.java
@@ -13,7 +13,6 @@ import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -24,11 +23,9 @@ import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.format.ConfigurationFormats;
 import org.apache.tamaya.inject.api.Config;
 import org.apache.tamaya.spi.PropertySource;
-import org.apache.tamaya.spisupport.propertysource.EnvironmentPropertySource;
 import org.slf4j.Logger;
 import org.trellisldp.http.TrellisHttpFilter;
 import org.trellisldp.http.TrellisHttpResource;
@@ -72,7 +69,7 @@ public class CassandraApplication extends Application {
      * Load in any additional configuration.
      */
     @PostConstruct
-    public void importAndArrangeAdditionalConfig() {
+    public void importAdditionalConfig() {
         // we require contained PUT because we use the Trellis WebDAV module, which requires it
         System.setProperty(CONFIG_HTTP_PUT_UNCONTAINED, "false");
         additionalConfigFile.map(this::toUrl).ifPresent(this::addConfig);
@@ -81,8 +78,6 @@ public class CassandraApplication extends Application {
         log(System.getProperties());
         log.debug("Using ENV vars:");
         log(System.getenv());
-        // put ENV properties first to cater for Docker expectations
-        setCurrent(current().toBuilder().highestPriority(new EnvironmentPropertySource()).build());
         log.debug("Using Tamaya configuration sources:");
         current().getContext().getPropertySources().stream().map(PropertySource::getName).forEach(log::debug);
         log.debug("Using Tamaya configuration:");


### PR DESCRIPTION
Removes prior fixes related to Docker and ENV variables for Tamaya
Converts Docker entrypoint to bash, which supported dotted ENV variables.
Adds tamaya.ordinal=500 to the set of ENV variables passed by Docker, giving ENV variables highest preference.
Converts docker config to dotted ENV variables, updating stack config file and added a .env defaults file.
Removes JMS, basic authn, and webac profiles from build. (These were broken anyway against current Trellis)